### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,303 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - release/*
+  pull_request:
+    branches:
+      - main
+      - release/*
+
+jobs:
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    timeout-minutes: 30
+    env:
+      CHILD_CONCURRENCY: "1"
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "2.x"
+
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "::set-output name=value::$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)"
+      - name: Cache node_modules archive
+        id: cacheNodeModules
+        uses: actions/cache@v2
+        with:
+          path: ".build/node_modules_cache"
+          key: "${{ runner.os }}-cacheNodeModulesArchive-${{ steps.nodeModulesCacheKey.outputs.value }}"
+      - name: Extract node_modules archive
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit == 'true' }}
+        run: 7z.exe x .build/node_modules_cache/cache.7z -aos
+      - name: Get yarn cache directory path
+        id: yarnCacheDirPath
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache yarn directory
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarnCacheDirPath.outputs.dir }}
+          key: ${{ runner.os }}-yarnCacheDir-${{ steps.nodeModulesCacheKey.outputs.value }}
+          restore-keys: ${{ runner.os }}-yarnCacheDir-
+      - name: Execute yarn
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+        run: yarn --frozen-lockfile --network-timeout 180000
+      - name: Create node_modules archive
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -Force .build
+          node build/azure-pipelines/common/listNodeModules.js .build/node_modules_list.txt
+          mkdir -Force .build/node_modules_cache
+          7z.exe a .build/node_modules_cache/cache.7z -mx3 `@.build/node_modules_list.txt
+
+      - name: Compile and Download
+        run: yarn npm-run-all --max_old_space_size=4095 -lp compile "electron x64" playwright-install download-builtin-extensions
+
+      - name: Run Unit Tests (Electron)
+        run: .\scripts\test.bat
+
+      - name: Run Unit Tests (Browser)
+        run: yarn test-browser --browser chromium
+
+      - name: Run Integration Tests (Electron)
+        run: .\scripts\test-integration.bat
+
+  linux:
+    name: Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      # TODO: rename azure-pipelines/linux/xvfb.init to github-actions
+      - name: Setup Build Environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0 libgbm1
+          sudo cp build/azure-pipelines/linux/xvfb.init /etc/init.d/xvfb
+          sudo chmod +x /etc/init.d/xvfb
+          sudo update-rc.d xvfb defaults
+          sudo service xvfb start
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "::set-output name=value::$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)"
+      - name: Cache node modules
+        id: cacheNodeModules
+        uses: actions/cache@v2
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-cacheNodeModules14-${{ steps.nodeModulesCacheKey.outputs.value }}
+          restore-keys: ${{ runner.os }}-cacheNodeModules14-
+      - name: Get yarn cache directory path
+        id: yarnCacheDirPath
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache yarn directory
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarnCacheDirPath.outputs.dir }}
+          key: ${{ runner.os }}-yarnCacheDir-${{ steps.nodeModulesCacheKey.outputs.value }}
+          restore-keys: ${{ runner.os }}-yarnCacheDir-
+      - name: Execute yarn
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+        run: yarn --frozen-lockfile --network-timeout 180000
+
+      - name: Compile and Download
+        run: yarn npm-run-all --max_old_space_size=4095 -lp compile "electron x64" playwright-install download-builtin-extensions
+
+      - name: Run Unit Tests (Electron)
+        id: electron-unit-tests
+        run: DISPLAY=:10 ./scripts/test.sh
+
+      - name: Run Unit Tests (Browser)
+        id: browser-unit-tests
+        run: DISPLAY=:10 yarn test-browser --browser chromium
+
+      - name: Run Integration Tests (Electron)
+        id: electron-integration-tests
+        run: DISPLAY=:10 ./scripts/test-integration.sh
+
+  darwin:
+    name: macOS
+    runs-on: macos-latest
+    timeout-minutes: 30
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "::set-output name=value::$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)"
+      - name: Cache node modules
+        id: cacheNodeModules
+        uses: actions/cache@v2
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-cacheNodeModules14-${{ steps.nodeModulesCacheKey.outputs.value }}
+          restore-keys: ${{ runner.os }}-cacheNodeModules14-
+      - name: Get yarn cache directory path
+        id: yarnCacheDirPath
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache yarn directory
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarnCacheDirPath.outputs.dir }}
+          key: ${{ runner.os }}-yarnCacheDir-${{ steps.nodeModulesCacheKey.outputs.value }}
+          restore-keys: ${{ runner.os }}-yarnCacheDir-
+      - name: Execute yarn
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+        run: yarn --frozen-lockfile --network-timeout 180000
+
+      - name: Compile and Download
+        run: yarn npm-run-all --max_old_space_size=4095 -lp compile "electron x64" playwright-install download-builtin-extensions
+
+      # This is required for keytar unittests, otherwise we hit
+      # https://github.com/atom/node-keytar/issues/76
+      - name: Create temporary keychain
+        run: |
+          security create-keychain -p pwd $RUNNER_TEMP/buildagent.keychain
+          security default-keychain -s $RUNNER_TEMP/buildagent.keychain
+          security unlock-keychain -p pwd $RUNNER_TEMP/buildagent.keychain
+
+      - name: Run Unit Tests (Electron)
+        run: DISPLAY=:10 ./scripts/test.sh
+
+      - name: Run Unit Tests (Browser)
+        run: DISPLAY=:10 yarn test-browser --browser chromium
+
+      - name: Run Integration Tests (Electron)
+        run: DISPLAY=:10 ./scripts/test-integration.sh
+
+  hygiene:
+    name: Hygiene, Layering and Monaco Editor
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "::set-output name=value::$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)"
+      - name: Cache node modules
+        id: cacheNodeModules
+        uses: actions/cache@v2
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-cacheNodeModules14-${{ steps.nodeModulesCacheKey.outputs.value }}
+          restore-keys: ${{ runner.os }}-cacheNodeModules14-
+      - name: Get yarn cache directory path
+        id: yarnCacheDirPath
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache yarn directory
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarnCacheDirPath.outputs.dir }}
+          key: ${{ runner.os }}-yarnCacheDir-${{ steps.nodeModulesCacheKey.outputs.value }}
+          restore-keys: ${{ runner.os }}-yarnCacheDir-
+      - name: Execute yarn
+        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+        run: yarn --frozen-lockfile --network-timeout 180000
+
+      - name: Run Hygiene Checks
+        run: yarn gulp hygiene
+
+      - name: Run Valid Layers Checks
+        run: yarn valid-layers-check
+
+      - name: Compile /build/
+        run: yarn --cwd build compile
+
+      - name: Run eslint
+        run: yarn eslint
+
+      - name: Run Monaco Editor Checks
+        run: yarn monaco-compile-check
+
+      - name: Run vscode-dts Compile Checks
+        run: yarn vscode-dts-compile-check
+
+      - name: Run Trusted Types Checks
+        run: yarn tsec-compile-check
+
+      - name: Editor Distro & ESM Bundle
+        run: yarn gulp editor-esm-bundle
+
+      - name: Typings validation prep
+        run: |
+          mkdir typings-test
+
+      - name: Typings validation
+        working-directory: ./typings-test
+        run: |
+          yarn init -yp
+          ../node_modules/.bin/tsc --init
+          echo "import '../out-monaco-editor-core';" > a.ts
+          ../node_modules/.bin/tsc --noEmit
+
+      - name: Webpack Editor
+        working-directory: ./test/monaco
+        run: yarn run bundle
+
+      - name: Compile Editor Tests
+        working-directory: ./test/monaco
+        run: yarn run compile
+
+      - name: Download Playwright
+        run: yarn playwright-install
+
+      - name: Run Editor Tests
+        timeout-minutes: 5
+        working-directory: ./test/monaco
+        run: yarn test
+
 # ck
 .ck
 


### PR DESCRIPTION
name: CI

on:
  push:
    branches:
      - main
      - release/*
  pull_request:
    branches:
      - main
      - release/*

jobs:
  windows:
    name: Windows
    runs-on: windows-latest
    timeout-minutes: 30
    env:
      CHILD_CONCURRENCY: "1"
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    steps:
      - uses: actions/checkout@v2

      - uses: actions/setup-node@v2
        with:
          node-version: 14

      - uses: actions/setup-python@v2
        with:
          python-version: "2.x"

      - name: Compute node modules cache key
        id: nodeModulesCacheKey
        run: echo "::set-output name=value::$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)"
      - name: Cache node_modules archive
        id: cacheNodeModules
        uses: actions/cache@v2
        with:
          path: ".build/node_modules_cache"
          key: "${{ runner.os }}-cacheNodeModulesArchive-${{ steps.nodeModulesCacheKey.outputs.value }}"
      - name: Extract node_modules archive
        if: ${{ steps.cacheNodeModules.outputs.cache-hit == 'true' }}
        run: 7z.exe x .build/node_modules_cache/cache.7z -aos
      - name: Get yarn cache directory path
        id: yarnCacheDirPath
        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
        run: echo "::set-output name=dir::$(yarn cache dir)"
      - name: Cache yarn directory
        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
        uses: actions/cache@v2
        with:
          path: ${{ steps.yarnCacheDirPath.outputs.dir }}
          key: ${{ runner.os }}-yarnCacheDir-${{ steps.nodeModulesCacheKey.outputs.value }}
          restore-keys: ${{ runner.os }}-yarnCacheDir-
      - name: Execute yarn
        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
        env:
          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
        run: yarn --frozen-lockfile --network-timeout 180000
      - name: Create node_modules archive
        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
        run: |
          mkdir -Force .build
          node build/azure-pipelines/common/listNodeModules.js .build/node_modules_list.txt
          mkdir -Force .build/node_modules_cache
          7z.exe a .build/node_modules_cache/cache.7z -mx3 `@.build/node_modules_list.txt

      - name: Compile and Download
        run: yarn npm-run-all --max_old_space_size=4095 -lp compile "electron x64" playwright-install download-builtin-extensions

      - name: Run Unit Tests (Electron)
        run: .\scripts\test.bat

      - name: Run Unit Tests (Browser)
        run: yarn test-browser --browser chromium

      - name: Run Integration Tests (Electron)
        run: .\scripts\test-integration.bat

  linux:
    name: Linux
    runs-on: ubuntu-latest
    timeout-minutes: 30
    env:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    steps:
      - uses: actions/checkout@v2

      # TODO: rename azure-pipelines/linux/xvfb.init to github-actions
      - name: Setup Build Environment
        run: |
          sudo apt-get update
          sudo apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0 libgbm1
          sudo cp build/azure-pipelines/linux/xvfb.init /etc/init.d/xvfb
          sudo chmod +x /etc/init.d/xvfb
          sudo update-rc.d xvfb defaults
          sudo service xvfb start

      - uses: actions/setup-node@v2
        with:
          node-version: 14

      - name: Compute node modules cache key
        id: nodeModulesCacheKey
        run: echo "::set-output name=value::$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)"
      - name: Cache node modules
        id: cacheNodeModules
        uses: actions/cache@v2
        with:
          path: "**/node_modules"
          key: ${{ runner.os }}-cacheNodeModules14-${{ steps.nodeModulesCacheKey.outputs.value }}
          restore-keys: ${{ runner.os }}-cacheNodeModules14-
      - name: Get yarn cache directory path
        id: yarnCacheDirPath
        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
        run: echo "::set-output name=dir::$(yarn cache dir)"
      - name: Cache yarn directory
        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
        uses: actions/cache@v2
        with:
          path: ${{ steps.yarnCacheDirPath.outputs.dir }}
          key: ${{ runner.os }}-yarnCacheDir-${{ steps.nodeModulesCacheKey.outputs.value }}
          restore-keys: ${{ runner.os }}-yarnCacheDir-
      - name: Execute yarn
        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
        env:
          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
        run: yarn --frozen-lockfile --network-timeout 180000

      - name: Compile and Download
        run: yarn npm-run-all --max_old_space_size=4095 -lp compile "electron x64" playwright-install download-builtin-extensions

      - name: Run Unit Tests (Electron)
        id: electron-unit-tests
        run: DISPLAY=:10 ./scripts/test.sh

      - name: Run Unit Tests (Browser)
        id: browser-unit-tests
        run: DISPLAY=:10 yarn test-browser --browser chromium

      - name: Run Integration Tests (Electron)
        id: electron-integration-tests
        run: DISPLAY=:10 ./scripts/test-integration.sh

  darwin:
    name: macOS
    runs-on: macos-latest
    timeout-minutes: 30
    env:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    steps:
      - uses: actions/checkout@v2

      - uses: actions/setup-node@v2
        with:
          node-version: 14

      - name: Compute node modules cache key
        id: nodeModulesCacheKey
        run: echo "::set-output name=value::$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)"
      - name: Cache node modules
        id: cacheNodeModules
        uses: actions/cache@v2
        with:
          path: "**/node_modules"
          key: ${{ runner.os }}-cacheNodeModules14-${{ steps.nodeModulesCacheKey.outputs.value }}
          restore-keys: ${{ runner.os }}-cacheNodeModules14-
      - name: Get yarn cache directory path
        id: yarnCacheDirPath
        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
        run: echo "::set-output name=dir::$(yarn cache dir)"
      - name: Cache yarn directory
        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
        uses: actions/cache@v2
        with:
          path: ${{ steps.yarnCacheDirPath.outputs.dir }}
          key: ${{ runner.os }}-yarnCacheDir-${{ steps.nodeModulesCacheKey.outputs.value }}
          restore-keys: ${{ runner.os }}-yarnCacheDir-
      - name: Execute yarn
        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
        env:
          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
        run: yarn --frozen-lockfile --network-timeout 180000

      - name: Compile and Download
        run: yarn npm-run-all --max_old_space_size=4095 -lp compile "electron x64" playwright-install download-builtin-extensions

      # This is required for keytar unittests, otherwise we hit
      # https://github.com/atom/node-keytar/issues/76
      - name: Create temporary keychain
        run: |
          security create-keychain -p pwd $RUNNER_TEMP/buildagent.keychain
          security default-keychain -s $RUNNER_TEMP/buildagent.keychain
          security unlock-keychain -p pwd $RUNNER_TEMP/buildagent.keychain

      - name: Run Unit Tests (Electron)
        run: DISPLAY=:10 ./scripts/test.sh

      - name: Run Unit Tests (Browser)
        run: DISPLAY=:10 yarn test-browser --browser chromium

      - name: Run Integration Tests (Electron)
        run: DISPLAY=:10 ./scripts/test-integration.sh

  hygiene:
    name: Hygiene, Layering and Monaco Editor
    runs-on: ubuntu-latest
    timeout-minutes: 30
    env:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    steps:
      - uses: actions/checkout@v2

      - uses: actions/setup-node@v2
        with:
          node-version: 14

      - name: Compute node modules cache key
        id: nodeModulesCacheKey
        run: echo "::set-output name=value::$(node build/azure-pipelines/common/computeNodeModulesCacheKey.js)"
      - name: Cache node modules
        id: cacheNodeModules
        uses: actions/cache@v2
        with:
          path: "**/node_modules"
          key: ${{ runner.os }}-cacheNodeModules14-${{ steps.nodeModulesCacheKey.outputs.value }}
          restore-keys: ${{ runner.os }}-cacheNodeModules14-
      - name: Get yarn cache directory path
        id: yarnCacheDirPath
        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
        run: echo "::set-output name=dir::$(yarn cache dir)"
      - name: Cache yarn directory
        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
        uses: actions/cache@v2
        with:
          path: ${{ steps.yarnCacheDirPath.outputs.dir }}
          key: ${{ runner.os }}-yarnCacheDir-${{ steps.nodeModulesCacheKey.outputs.value }}
          restore-keys: ${{ runner.os }}-yarnCacheDir-
      - name: Execute yarn
        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
        env:
          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
        run: yarn --frozen-lockfile --network-timeout 180000

      - name: Run Hygiene Checks
        run: yarn gulp hygiene

      - name: Run Valid Layers Checks
        run: yarn valid-layers-check

      - name: Compile /build/
        run: yarn --cwd build compile

      - name: Run eslint
        run: yarn eslint

      - name: Run Monaco Editor Checks
        run: yarn monaco-compile-check

      - name: Run vscode-dts Compile Checks
        run: yarn vscode-dts-compile-check

      - name: Run Trusted Types Checks
        run: yarn tsec-compile-check

      - name: Editor Distro & ESM Bundle
        run: yarn gulp editor-esm-bundle

      - name: Typings validation prep
        run: |
          mkdir typings-test

      - name: Typings validation
        working-directory: ./typings-test
        run: |
          yarn init -yp
          ../node_modules/.bin/tsc --init
          echo "import '../out-monaco-editor-core';" > a.ts
          ../node_modules/.bin/tsc --noEmit

      - name: Webpack Editor
        working-directory: ./test/monaco
        run: yarn run bundle

      - name: Compile Editor Tests
        working-directory: ./test/monaco
        run: yarn run compile

      - name: Download Playwright
        run: yarn playwright-install

      - name: Run Editor Tests
        timeout-minutes: 5
        working-directory: ./test/monaco
        run: yarn test

